### PR TITLE
Define raw_input() in Python 3

### DIFF
--- a/python/client.py
+++ b/python/client.py
@@ -28,6 +28,11 @@ import argparse
 import requests
 import urllib
 
+try:
+	raw_input  # Python 2
+except NameError:  # Python 3
+	raw_input = input
+
 openssl_cli_cnf_template_ = '''
 ####################################################################
 [ req ]


### PR DESCRIPTION
__raw_input()__ was removed in Python 3 in favor of a reworked version of __input()__.  This PR ensures equivalent functionality on both Python 2 and Python 3.

[flake8](http://flake8.pycqa.org) testing of https://github.com/ibm-research/data-store-for-memcache-client on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./python/client.py:422:28: F821 undefined name 'raw_input'
                user_arg = raw_input('Proceed (y/n)?')
                           ^
./python/client.py:469:24: F821 undefined name 'raw_input'
            user_arg = raw_input('Proceed (y/n)?')
                       ^
2     F821 undefined name 'raw_input'
2
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree